### PR TITLE
Fix react peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-json-formatter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Formatting json data to JSX of React",
   "author": "ronny1020",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": "^16.13.1"
+    "react": ">16.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
Currently you can't use this library with React 17.x because it depends on React 16.x as a peer depdency. However, this library should work fine with React 17.x and there is no reason yet to think it will break in future versions. The range can be closed off in future if things change.